### PR TITLE
Add options for min and max allowed age

### DIFF
--- a/src/components/CustomWelcome.vue
+++ b/src/components/CustomWelcome.vue
@@ -53,6 +53,8 @@
                         <input-text
                             v-model="age"
                             :label="$t('plugin-asl:age')"
+                            :min="allowedAge.min"
+                            :max="allowedAge.max"
                             class="kiwi-welcome-simple-age"
                             type="number"
                         />
@@ -161,6 +163,9 @@ export default {
         };
     },
     computed: {
+        allowedAge() {
+            return kiwi.state.getSetting('settings.plugin-asl.allowedAge');
+        },
         sexes() {
             return kiwi.state.getSetting('settings.plugin-asl.sexes');
         },
@@ -192,6 +197,10 @@ export default {
         },
         readyToStart: function readyToStart() {
             let ready = !!this.nick;
+
+            if (this.age && (this.age < this.allowedAge.min || this.age > this.allowedAge.max)) {
+                ready = false;
+            }
 
             if (!this.connectWithoutChannel && !this.channel) {
                 ready = false;

--- a/src/config.js
+++ b/src/config.js
@@ -32,6 +32,11 @@ export function setDefaults() {
         separator: ' ',
     });
 
+    setSettingDefault('plugin-asl.allowedAge', {
+        min: '18',
+        max: '99',
+    });
+
     // Age ranges to show on UserBrowser select
     // values can be:
     //   string - treated as all


### PR DESCRIPTION
If someone wants to allow to connect only from a specific age and over and until a certain number now it is possible.

This is also useful for example to allow only from 18+ to able to connect thought.

Example Config:

```
"allowedAge": {
      "min": "18",
      "max": "70"
},
```